### PR TITLE
fix clang compilation: strip inline keyword

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -22,8 +22,8 @@
 
 static loglevel_t loglevel = LOG_WARNING;
 
-inline static char* get_levelstring(loglevel_t level);
-inline char* get_timestring(void);
+static char* get_levelstring(loglevel_t level);
+char* get_timestring(void);
 
 loglevel_t get_loglevel(void)
 {
@@ -74,7 +74,7 @@ void log_msg(loglevel_t level, const char *fmt, ...)
     xfree(msg);
 }
 
-inline char* get_timestring(void)
+char* get_timestring(void)
 {
     time_t timee;
     struct tm *timeinfo;
@@ -88,7 +88,7 @@ inline char* get_timestring(void)
     return time_s;
 }
 
-inline char* get_levelstring(loglevel_t level)
+char* get_levelstring(loglevel_t level)
 {
     switch (level) {
         case LOG_INFO:

--- a/src/packetcapture.c
+++ b/src/packetcapture.c
@@ -105,7 +105,7 @@ void packetcapture_close(void)
 		pcap_close(pc);
 }
 
-inline char* get_default_interface()
+char* get_default_interface()
 {
     char ebuf[PCAP_ERRBUF_SIZE];
     char *interface;
@@ -122,7 +122,7 @@ inline char* get_default_interface()
     return interface;
 }
 
-inline void packetcapture_dispatch(void)
+void packetcapture_dispatch(void)
 {
     pcap_dispatch(pc, -1, process_packet, NULL);
 }

--- a/src/packetcapture.h
+++ b/src/packetcapture.h
@@ -23,8 +23,8 @@ void packetcapture_open_live(char* interface, char* filterexpr, int promisc);
 void packetcapture_open_offline(char* dumpfile);
 void packetcapture_close(void);
 
-inline void packetcapture_dispatch(void);
+void packetcapture_dispatch(void);
 
-inline char* get_default_interface();
+char* get_default_interface();
 
 #endif  /* __PACKETCAPTURE_H__ */

--- a/src/tmpdir.c
+++ b/src/tmpdir.c
@@ -75,7 +75,7 @@ void set_tmpdir(const char *dir, tmpdir_type_t type, int max_files, int preserve
     log_msg(LOG_INFO, "using temporary file directory %s", tmpdir.path);
 }
 
-inline const char* get_tmpdir(void)
+const char* get_tmpdir(void)
 {
     assert (tmpdir.path != NULL);
 

--- a/src/tmpdir.h
+++ b/src/tmpdir.h
@@ -20,7 +20,7 @@
 typedef enum { TMPDIR_APP_OWNED = 0, TMPDIR_USER_OWNED = 1 } tmpdir_type_t;
 
 void set_tmpdir(const char *dir, tmpdir_type_t type, int max_files, int preserve_files);
-inline const char* get_tmpdir(void);
+const char* get_tmpdir(void);
 void clean_tmpdir();
 
 const char* make_tmpdir(void);


### PR DESCRIPTION
The `inline` keyword actually changes the semantics in c99, instead of just acting as a hint.  The usage in driftnet is incorrect.

http://clang.llvm.org/compatibility.html#inline explains why `clang` does different things.

Testcase:

```
./configure CC=clang CXX=clang++ && make
```
