### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+driftnet (1.1.5-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 21:10:29 +0100
+
 driftnet (1.1.5-1) unstable; urgency=medium
 
   * Imported Upstream version 1.1.5

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), libgtk2.0-dev, libpcap-dev, libjpeg-dev, libgif
 Standards-Version: 3.9.5
 Homepage: https://github.com/deiv/driftnet
 Vcs-Browser: https://github.com/deiv/driftnet
-Vcs-Git: git://github.com/deiv/driftnet.git -b debian
+Vcs-Git: https://github.com/deiv/driftnet.git -b debian
 
 Package: driftnet
 Architecture: any


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
