### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+driftnet (1.3.0+dfsg-3) UNRELEASED; urgency=medium
+
+  * Drop unnecessary dependency on dh-autoreconf.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:41:43 +0000
+
 driftnet (1.3.0+dfsg-2) unstable; urgency=medium
 
   * Upload to unstable.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ driftnet (1.3.0+dfsg-3) UNRELEASED; urgency=medium
 
   * Drop unnecessary dependency on dh-autoreconf.
   * Fix day-of-week for changelog entries 0.1.6-6, 0.1.6-5.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:41:43 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 driftnet (1.3.0+dfsg-3) UNRELEASED; urgency=medium
 
   * Drop unnecessary dependency on dh-autoreconf.
+  * Fix day-of-week for changelog entries 0.1.6-6, 0.1.6-5.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:41:43 +0000
 
@@ -174,7 +175,7 @@ driftnet (0.1.6-6) unstable; urgency=low
   * Added .desktop file, from Ubuntu.
     (Closes: #375511)
 
- -- Steve Kemp <skx@debian.org>  Thu,  26 June 2006 16:12:04 +0000
+ -- Steve Kemp <skx@debian.org>  Mon, 26 Jun 2006 16:12:04 +0000
 
 driftnet (0.1.6-5) unstable; urgency=low
 
@@ -182,7 +183,7 @@ driftnet (0.1.6-5) unstable; urgency=low
     (Closes: #337400)
   * Updated standards version to 3.7.2, no changes.
 
- -- Steve Kemp <skx@debian.org>  Thu,  12 May 2006 15:57:43 +0000
+ -- Steve Kemp <skx@debian.org>  Fri, 12 May 2006 15:57:43 +0000
 
 driftnet (0.1.6-4) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper-compat (= 12),
                libpng-dev,
                libwebsockets-dev (>= 3.2.0)
 Rules-Requires-Root: no
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Homepage: https://github.com/deiv/driftnet
 Vcs-Browser: https://github.com/deiv/driftnet
 Vcs-Git: https://github.com/deiv/driftnet.git -b debian

--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ --with autoreconf
+	dh $@
 
 override_dh_auto_build:
     #


### PR DESCRIPTION
Fix some issues reported by lintian
* Drop unnecessary dependency on dh-autoreconf. ([useless-autoreconf-build-depends](https://lintian.debian.org/tags/useless-autoreconf-build-depends.html))
* Fix day-of-week for changelog entries 0.1.6-6, 0.1.6-5. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/driftnet/31945bd4-6538-48e4-8ace-e6bc758a8873.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/73/004a64691bd54ec9ccf50becca9f884d8a5314.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6e/6d28ed5b03fa66dcb42146507907699b8e067e.debug

No differences were encountered between the control files of package \*\*driftnet\*\*
### Control files of package driftnet-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-6e6d28ed5b03fa66dcb42146507907699b8e067e-] {+73004a64691bd54ec9ccf50becca9f884d8a5314+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/31945bd4-6538-48e4-8ace-e6bc758a8873/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/31945bd4-6538-48e4-8ace-e6bc758a8873/diffoscope)).
