### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,8 @@ Build-Depends: debhelper-compat (= 12),
                libgif-dev,
                libgtk2.0-dev,
                libjpeg-dev,
-               libjs-jquery (>= 3.3.1~dfsg),
-               libjs-lightbox2  (>= 2.11.1+dfsg),
+               libjs-jquery,
+               libjs-lightbox2 (>= 2.11.1+dfsg),
                libpcap-dev,
                libpng-dev,
                libwebsockets-dev (>= 3.2.0)
@@ -20,7 +20,7 @@ Vcs-Git: https://github.com/deiv/driftnet.git -b debian
 
 Package: driftnet
 Architecture: any
-Depends: libjs-jquery (>= 3.3.1~dfsg),
+Depends: libjs-jquery,
          libjs-lightbox2 (>= 2.11.1+dfsg),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/driftnet/eaae1871-8271-4ae5-a263-8b00c8e8e306.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ca/69f7c26d5e162c5018cc16abfeeae414205a1c.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/94/45049b3b345d96ecf4d401d7d00db365114bd6.debug
### Control files of package driftnet: lines which differ (wdiff format)
* Depends: [-libjs-jquery (>= 3.3.1~dfsg),-] {+libjs-jquery,+} libjs-lightbox2 (>= 2.11.1+dfsg), libc6 (>= 2.33), libgif7 (>= 5.1), libglib2.0-0 (>= 2.12.0), libgtk2.0-0 (>= 2.8.0), libjpeg62-turbo (>= 1.3.1), libpcap0.8 (>= 1.0.0), libpng16-16 (>= 1.6.2-1), libwebsockets16 (>= 2.4.1)
### Control files of package driftnet-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-9445049b3b345d96ecf4d401d7d00db365114bd6-] {+ca69f7c26d5e162c5018cc16abfeeae414205a1c+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/eaae1871-8271-4ae5-a263-8b00c8e8e306/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/eaae1871-8271-4ae5-a263-8b00c8e8e306/diffoscope)).
