### PR TITLE
fix test_unit with gcc-15 / use standard uint* instead of u_int

### DIFF
--- a/src/media/image.c
+++ b/src/media/image.c
@@ -299,7 +299,7 @@ unsigned char *find_jpeg_image(const unsigned char *data, const size_t len, unsi
 unsigned char *find_png_eoi(unsigned char *buffer, const size_t len) {
     unsigned char *end_data, *data, chunk_code[PNG_CODE_LEN + 1];
     struct png_chunk chunk;
-    u_int32_t datalen;
+    uint32_t datalen;
 
     /* Move past the PNG header */
     data = (buffer + PNG_SIG_LEN);
@@ -462,11 +462,11 @@ unsigned char *find_avif_image(const unsigned char *data, const size_t len, unsi
     avifhdr = avifhdr - 4;
 
     unsigned char *current_box = avifhdr;
-    u_int32_t current_box_len = __bswap_32(*((u_int32_t*) avifhdr));
+    uint32_t current_box_len = __bswap_32(*((uint32_t*) avifhdr));
 
     while (len > (current_box + current_box_len + 8) - avifhdr) {
         current_box = current_box + current_box_len;
-        current_box_len = __bswap_32(*((u_int32_t *) current_box));
+        current_box_len = __bswap_32(*((uint32_t *) current_box));
 
         unsigned char *current_box_type = current_box + 4;
 
@@ -475,7 +475,7 @@ unsigned char *find_avif_image(const unsigned char *data, const size_t len, unsi
             continue;
         }
 
-        u_int32_t file_len = (current_box - avifhdr) + current_box_len;
+        uint32_t file_len = (current_box - avifhdr) + current_box_len;
 
         /* enough room ? */
         if (len >= file_len) {

--- a/src/media/tests/test_unit.c
+++ b/src/media/tests/test_unit.c
@@ -7,6 +7,8 @@
  *
  */
 
+#include "compat/compat.h"
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -244,7 +246,7 @@ void test_dont_parse_other_formats(void** state)
     }
 }
 
-void test_correct_media_drivers_for_mediatype_count()
+void test_correct_media_drivers_for_mediatype_count(void **state)
 {
     drivers_t* image_drivers = NULL;
     drivers_t* audio_drivers = NULL;

--- a/src/network/layer2.c
+++ b/src/network/layer2.c
@@ -39,7 +39,7 @@
 struct ethhdr {
 	unsigned char   h_dest[ETH_ALEN];
 	unsigned char   h_source[ETH_ALEN];
-	u_int16_t       h_proto;
+	uint16_t       h_proto;
 } __attribute__((packed));
 #endif
 
@@ -55,19 +55,19 @@ struct ethhdr {
 #endif
 
 struct ieee80211_radiotap_header {
-	u_int8_t        it_version;     /* set to 0 */
-	u_int8_t        it_pad;
-	u_int16_t       it_len;         /* entire length */
-	u_int32_t       it_present;     /* fields present */
+	uint8_t        it_version;     /* set to 0 */
+	uint8_t        it_pad;
+	uint16_t       it_len;         /* entire length */
+	uint32_t       it_present;     /* fields present */
 };
 
 struct ieee80211_frame {
-    u_int16_t fc;
-    u_int16_t wi_duration;
-    u_int8_t wi_add1[6];
-    u_int8_t wi_add2[6];
-    u_int8_t wi_add3[6];
-    u_int16_t wi_sequenceControl;
+    uint16_t fc;
+    uint16_t wi_duration;
+    uint8_t wi_add1[6];
+    uint8_t wi_add2[6];
+    uint8_t wi_add3[6];
+    uint16_t wi_sequenceControl;
     // u_int8_t wi_add4[6];
     //unsigned int qosControl:2;
     //unsigned int frameBody[23124];
@@ -89,13 +89,13 @@ struct frame_control {
 
 /* SNAP LLC header format */
 struct snap_header {
-  u_int8_t dsap;
-  u_int8_t ssap;
-  u_int8_t ctl;
-  u_int8_t org1;
-  u_int8_t org2;
-  u_int8_t org3;
-  u_int16_t ether_type;          /* ethernet type */
+  uint8_t dsap;
+  uint8_t ssap;
+  uint8_t ctl;
+  uint8_t org1;
+  uint8_t org2;
+  uint8_t org3;
+  uint16_t ether_type;          /* ethernet type */
 };
 
 /*

--- a/src/network/layer3.c
+++ b/src/network/layer3.c
@@ -30,8 +30,8 @@
 int layer3_find_tcp(const u_char *pkt, uint8_t nextproto, int * offset,
 		struct sockaddr * src, struct sockaddr * dst, struct tcphdr * tcp)
 {
-	u_int16_t *sport = NULL;
-	u_int16_t *dport = NULL;
+	uint16_t *sport = NULL;
+	uint16_t *dport = NULL;
 
 	while (1) {
 		switch (nextproto) {


### PR DESCRIPTION
fix test_unit:
>tests/test_unit.c:152:9: error: use of undeclared identifier 'uintptr_t'; did
>      you mean 'intptr_t'?
>  152 |         assert_null(media_data);

>tests/test_unit.c: In function ‘main’:
>tests/test_unit.c:297:30: error: initialization of ‘void (*)(void **)’
>from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
>  297 |             cmocka_unit_test(test_correct_media_drivers_for_mediatype_count)

use uint*, thus fix building w/ musl:
>image.c:466:5: error: unknown type name 'u_int32_t'; did you mean 'uint32_t'?
>  466 |     u_int32_t current_box_len = __bswap_32(*((u_int32_t*) avifhdr));
>      |     ^~~~~~~~~
>      |     uint32_t